### PR TITLE
非同期通信を用いたメッセージ送信画面の作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,8 @@ group :development, :test do
   gem 'rails-controller-testing'
   gem 'faker'
   gem 'capybara'
+  gem 'pry-rails'
+  gem 'pry-byebug'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'font-awesome-rails'
 gem 'devise'
 gem 'carrierwave'
 gem 'mini_magick'
+gem 'jquery-rails'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,7 @@ GEM
       image_processing (~> 1.1)
       mimemagic (>= 0.3.0)
       mini_mime (>= 0.1.3)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -136,6 +137,14 @@ GEM
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.7.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (3.1.1)
     puma (3.12.1)
     rack (2.0.7)
@@ -263,6 +272,8 @@ DEPENDENCIES
   listen (~> 3.0.5)
   mini_magick
   mysql2 (>= 0.3.18, < 0.6.0)
+  pry-byebug
+  pry-rails
   puma (~> 3.0)
   rails (~> 5.0.7, >= 5.0.7.2)
   rails-controller-testing

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,19 @@
+$(function(){
+  $('.form-box').on('submit', function(e){
+    e.preventDefaul();
+    let formData = new FormData(this);
+
+    $.ajax({
+      type: 'post',
+      url: '',
+      data: '',
+      dataType: 'json'
+    })
+    .done(function(){
+
+    })
+    .fail(function(){
+
+    });
+  });
+});

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,7 +1,10 @@
 $(function(){
-  $('.form-box').on('submit', function(e){
-    e.preventDefaul();
+  $('.form__box').on('submit', function(e){
+    e.preventDefault();
     let formData = new FormData(this);
+    for(item of formData){
+      console.log(item);
+    }
 
     $.ajax({
       type: 'post',

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,6 +1,18 @@
 $(function(){
   let messages_list = $('.messages');
+
   function addMessageHtml(message){
+    let text_and_image = "";
+
+    if (message.text != "") {
+      text_and_image += `<p class="message__list__box__text">
+      ${message.text}
+      </p>`
+    }
+    if (message.image != "") {
+      text_and_image += `<img src=${message.image.url} alt=" lz5lk5v 400x400">`
+    }
+    
     let html =`<div class="message">
     <ul class="message__list">
     <li class="message__list__info">
@@ -11,11 +23,7 @@ $(function(){
     ${message.timestamp}
     </p>
     </li>
-    <li class="message__list__box">
-    <p class="message__list__box__text">
-    ${message.text}
-    </p>
-    
+    ${text_and_image}
     </li>
     </ul>
     </div>`
@@ -27,6 +35,9 @@ $(function(){
     e.preventDefault();
     let formData = new FormData(this);
     let url = $(this).attr('action');
+    for(item of formData){
+      console.log(item);
+    }
     $.ajax({
       type: 'post',
       url: url,
@@ -39,7 +50,7 @@ $(function(){
       addMessageHtml(message);
     })
     .fail(function(){
-
+      alert('送信に失敗しました')
     });
   });
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -9,7 +9,8 @@ $(function(){
       ${message.text}
       </p>`
     }
-    if (message.image != "") {
+    if (message.image.url != null) {
+      console.log(message.image);
       text_and_image += `<img src=${message.image.url} alt=" lz5lk5v 400x400">`
     }
     
@@ -35,9 +36,6 @@ $(function(){
     e.preventDefault();
     let formData = new FormData(this);
     let url = $(this).attr('action');
-    for(item of formData){
-      console.log(item);
-    }
     $.ajax({
       type: 'post',
       url: url,
@@ -48,6 +46,10 @@ $(function(){
     })
     .done(function(message){
       addMessageHtml(message);
+      console.log(messages_list.height());
+      messages_list.animate({
+        scrollTop: messages_list.height()
+      });
     })
     .fail(function(){
       alert('送信に失敗しました')

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -31,6 +31,12 @@ $(function(){
 
     messages_list.append(html);
   }
+
+  function scrollBottom(base){
+    base.animate({
+      scrollTop: base[0].scrollHeight
+    });
+  }
   
   $('.form__box').on('submit', function(e){
     e.preventDefault();
@@ -46,13 +52,12 @@ $(function(){
     })
     .done(function(message){
       addMessageHtml(message);
-      console.log(messages_list.height());
-      messages_list.animate({
-        scrollTop: messages_list.height()
-      });
+      scrollBottom(messages_list);
     })
     .fail(function(){
       alert('送信に失敗しました')
     });
+
+    return false;
   });
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,15 +2,14 @@ $(function(){
   $('.form__box').on('submit', function(e){
     e.preventDefault();
     let formData = new FormData(this);
-    for(item of formData){
-      console.log(item);
-    }
-
+    let url = $(this).attr('action');
     $.ajax({
       type: 'post',
-      url: '',
-      data: '',
-      dataType: 'json'
+      url: url,
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
     })
     .done(function(){
 

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,4 +1,28 @@
 $(function(){
+  let messages_list = $('.messages');
+  function addMessageHtml(message){
+    let html =`<div class="message">
+    <ul class="message__list">
+    <li class="message__list__info">
+    <p class="message__list__info__name">
+    ${message.user_name}
+    </p>
+    <p class="message__list__info__date">
+    ${message.timestamp}
+    </p>
+    </li>
+    <li class="message__list__box">
+    <p class="message__list__box__text">
+    ${message.text}
+    </p>
+    
+    </li>
+    </ul>
+    </div>`
+
+    messages_list.append(html);
+  }
+  
   $('.form__box').on('submit', function(e){
     e.preventDefault();
     let formData = new FormData(this);
@@ -11,8 +35,8 @@ $(function(){
       processData: false,
       contentType: false
     })
-    .done(function(){
-
+    .done(function(message){
+      addMessageHtml(message);
     })
     .fail(function(){
 

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -3,14 +3,13 @@ $(function(){
 
   function addMessageHtml(message){
     let text_and_image = "";
-
+    
     if (message.text != "") {
       text_and_image += `<p class="message__list__box__text">
       ${message.text}
       </p>`
     }
     if (message.image.url != null) {
-      console.log(message.image);
       text_and_image += `<img src=${message.image.url} alt=" lz5lk5v 400x400">`
     }
     

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -50,6 +50,7 @@
   background-color: #2f3e51;
   padding: 0 20px;
   height: calc(100vh - #{$side-header-height});
+  overflow: scroll;
 }
 
 .group{
@@ -102,6 +103,7 @@
   background-color: #fafafa;
   padding: 0 40px;
   padding-top: 23px;
+  overflow: scroll;
 }
 
 .message{

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -154,6 +154,7 @@
       &__image{
         position: absolute;
         right: 10px;
+        cursor: pointer;
         input{
           display: none;
         }

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,10 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.html {redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'}
+        format.json {}
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,4 @@
 json.text @message.text
 json.image @message.image
-json.group_id @message.group_id
-json.user_id @message.user_id
+json.timestamp @message.created_at
+json.user_name @message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.text @message.text
+json.image @message.image
+json.group_id @message.group_id
+json.user_id @message.user_id

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,4 @@
 json.text @message.text
 json.image @message.image
-json.timestamp @message.created_at
+json.timestamp @message.created_at.strftime("%Y/%m/%d %H:%M")
 json.user_name @message.user.name

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -19,5 +19,5 @@
           = f.text_field :text, class: 'form__box__inputs__text', placeholder: 'type a text'
           = f.label :image, class: 'form__box__inputs__image' do
             = fa_icon 'image'
-            = f.text_field :image
+            = f.file_field :image
         = f.submit 'Send', class: "form__box__send-button"

--- a/app/views/shared/_group.html.haml
+++ b/app/views/shared/_group.html.haml
@@ -1,4 +1,4 @@
-=link_to " " do
+=link_to "/groups/#{group.id}/messages" do
   .group
     %p.group__title
       = group.name

--- a/app/views/shared/_group.html.haml
+++ b/app/views/shared/_group.html.haml
@@ -1,4 +1,4 @@
-=link_to "/groups/#{group.id}/messages" do
+=link_to group_messages_path(group.id) do
   .group
     %p.group__title
       = group.name


### PR DESCRIPTION
# WHAT
非同期通信を用いたメッセージ送信画面の作成
## 概要
messages#index内でAPIを作成し、views/messages/index.html.hamlにおいてmessage.jsで定義したajaxを用いた非同期通信を行うイベントを実行。message#createを呼び出し、formで送ったデータをjson形式でhtml.hamlに返す。

## 各動作
- 非同期通信の実行を確認
- 画面をリロードせずに投稿できる事を確認
- 連続での投稿を確認
- 投稿と同時に最下部までスクロールする事を確認
- 日時表記が適切な事を確認

### 参考gif
![9c430ea20cec201a39103962c453d174](https://user-images.githubusercontent.com/54299543/63691838-3b081a80-c84b-11e9-9b47-1107a1f193b1.gif)

# WHY
これまではメッセージを送信するたびにメールを再読み込みしていたので
より利便性を高めるために非同期通信を実装した。